### PR TITLE
Rename acr lookup to mb canonical data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 RUN mkdir /hoster
 WORKDIR /hoster
-COPY . /hoster
+
+COPY requirements.txt /hoster
 RUN python -m pip install -r requirements.txt
+
+COPY . /hoster
 # Change the COPY command below to copy any config files or other 
 # modules you may need (e.g. config.py) to /app:
 COPY main.py config.py /app/

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from area_random_recording import AreaRandomRecordingQuery
 from area_lookup import AreaLookupQuery
 #from genre_lookup import GenreLookupQuery
 from artist_country_from_artist_credit_id import ArtistCountryFromArtistCreditIdQuery
+from mb_canonical_data import MusicBrainzCanonicalDataLookup
 from rec_similarity import RecordingSimilarityQuery
 from upcoming_releases import UpcomingReleasesQuery
 
@@ -18,6 +19,7 @@ register_query(AreaRandomRecordingQuery())
 register_query(AreaLookupQuery())
 #register_query(GenreLookupQuery())
 register_query(ArtistCountryFromArtistCreditIdQuery())
+register_query(MusicBrainzCanonicalDataLookup())
 register_query(RecordingSimilarityQuery())
 register_query(UpcomingReleasesQuery())
 

--- a/mb_canonical_data.py
+++ b/mb_canonical_data.py
@@ -10,10 +10,10 @@ from unidecode import unidecode
 import config
 
 
-class ArtistCreditRecordingLookupQuery(Query):
+class MusicBrainzCanonicalDataLookup(Query):
 
     def names(self):
-        return ("acr-lookup", "MusicBrainz Artist Credit Recording lookup")
+        return ("mbc-lookup", "MusicBrainz Canonical Data lookup")
 
     def inputs(self):
         return ['[artist_credit_name]', '[recording_name]']
@@ -24,8 +24,8 @@ class ArtistCreditRecordingLookupQuery(Query):
 
     def outputs(self):
         return ['index', 'artist_credit_arg', 'recording_arg',
-                'artist_credit_name', 'release_name', 'recording_name', 
-                'artist_credit_id', 'release_mbid', 'recording_mbid']
+                'artist_credit_name', 'release_name', 'recording_name',
+                'artist_mbids', 'release_mbid', 'recording_mbid']
 
     def fetch(self, params, offset=-1, count=-1):
         lookup_strings = []
@@ -40,13 +40,13 @@ class ArtistCreditRecordingLookupQuery(Query):
         with psycopg2.connect(config.DB_CONNECT_MB) as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
                 curs.execute("""SELECT artist_credit_name,
-                                       artist_credit_id,
+                                       artist_mbids,
                                        release_name,
                                        release_mbid,
                                        recording_name,
                                        recording_mbid,
                                        combined_lookup
-                                  FROM mapping.mbid_mapping
+                                  FROM mapping.canonical_musicbrainz_data
                                  WHERE combined_lookup IN %s""", (lookup_strings,))
 
                 results = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click==7.1.2
+click==8.1.3
 psycopg2-binary==2.8.5
 ujson==2.0.3
 Unidecode==1.1.1
@@ -7,7 +7,7 @@ sentry-sdk[flask]==0.19.3
 typesense
 six
 python-Levenshtein
-git+https://github.com/mayhem/data-set-hoster.git@955d5c6#egg=datasethoster
+git+https://github.com/metabrainz/data-set-hoster.git@master#egg=datasethoster
 pysolr==3.9.0
 icecream
 fuzzywuzzy


### PR DESCRIPTION
Based on @mayhem's local changes

I didn't make the changes to `main.py` to integrate this new name, I'll do that.
I also built the image with the current requirements.txt file and it failed. I'm digging into why that's the case.